### PR TITLE
Fix: Prevent repeated screenshot checks on home screen navigation

### DIFF
--- a/app/src/main/java/com/neel/grepshot/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/neel/grepshot/ui/screens/home/HomeScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -189,7 +190,7 @@ fun HomeScreen(
     }
 
     // Add a state to track automatic background processing
-    var autoProcessingLaunched by remember { mutableStateOf(false) }
+    var autoProcessingLaunched by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(hasPermission) {
         if (hasPermission) {


### PR DESCRIPTION
The screenshot check and associated notifications were being triggered every time you navigated back to the home screen from another screen (e.g., the full-screen image view).

This was caused by the `autoProcessingLaunched` state variable in `HomeScreen.kt` being re-initialized to `false` on every recomposition.

The fix involves changing the state declaration from `remember { mutableStateOf(false) }` to
`rememberSaveable { mutableStateOf(false) }`.
This ensures that the `autoProcessingLaunched` state persists across recompositions and activity recreations, so the screenshot check logic only runs when the app is truly launched for the first time, or after a process death and recreation, not on simple back navigation.

Note: I was unable to automatically test this change due to Android SDK path issues in the execution environment. The fix relies on the standard behavior of `rememberSaveable` in Jetpack Compose.